### PR TITLE
Switch React to Vue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vue-blurhash-canvas
 
-> React components for using the [blurhash algorithm](https://blurha.sh) in your React projects
+> Vue components for using the [blurhash algorithm](https://blurha.sh) in your Vue projects
 
 ## Install
 ```


### PR DESCRIPTION
When searching for "Vue blurhash" on npm, this package showed this:
<img width="652" alt="image" src="https://user-images.githubusercontent.com/16364318/98892009-5faadb00-246d-11eb-9459-84436761e231.png">

Fixing this should remove a lot of confusion 😄 